### PR TITLE
Refactor Secrets and add WireGuard Support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,11 +42,11 @@ repos:
   - repo: https://github.com/igorshubovych/markdownlint-cli.git
     rev: v0.35.0
     hooks:
-      - id: markdownlint-docker
+      - id: markdownlint
         name: Check Markdown correctness and formatting
 
   - repo: https://github.com/zricethezav/gitleaks.git
     rev: v8.17.0
     hooks:
-      - id: gitleaks-docker
+      - id: gitleaks
         name: Check for hard-coded secrets, keys, and credentials

--- a/examples/ap.yaml
+++ b/examples/ap.yaml
@@ -15,6 +15,8 @@ description: |-
 
 settings:
   timezone: Europe/London
+
+secrets:
   ssh:
     key: |
       -- PRIVATE KEY --

--- a/examples/network.yaml
+++ b/examples/network.yaml
@@ -21,6 +21,15 @@ settings:
   wifi:
     country: united kingdom
 
+# The secrets map is a collection of values which cam be used as secrets,
+# specifically for this network, and mapped to by other values (e.g. psk.secret
+# for each WiFi network). Normally the secrets block should be empty, and
+# overridden by values from Vault.
+secrets:
+  wifi:
+    home: this-is-the-psk-for-home-wifi
+    guest: this-is-the-psk-for-guest-wifi
+
 ranges:
   # Define the internal ranges for the network, which will be used to lock down
   # all host-based services (SSH, WinBox, WebFig, Graphs, and WinBox) across the
@@ -201,10 +210,12 @@ vlans:
     # Where a VLAN is expected to be connected to a wireless interface (either
     # physically or virtually), the wifi block should be provided to set the
     # public name of that network, broadcast as its SSID, and the pre-shared-key
-    # (psk) which will be the WPA2 password (WPA1 will be disabled).
+    # (which can be found under secrets.wifi using the psk.secret key) which
+    # will be the WPA2 password (WPA1 will be disabled).
     wifi:
       ssid: Home WiFi
-      psk: this-is-the-psk-for-home-wifi
+      psk:
+        secret: home
     firewall:
       rules:
         - comment: Allow access to all networks and the Internet
@@ -221,8 +232,9 @@ vlans:
       address: 2001:0db8:8086:21::/64
       type: slaac
     wifi:
-      ssid: Private WiFi
-      psk: this-is-the-psk-for-private-wifi
+      ssid: Guest WiFi
+      psk:
+        secret: guest
     firewall:
       rules:
         - comment: Allow access to the Internet

--- a/examples/router.yaml
+++ b/examples/router.yaml
@@ -89,6 +89,17 @@ secrets:
     certificate: |
       -- CERTIFICATE --
 
+  # Wireguard requires keys for certificates on each end, and can support
+  # pre-shared-keys as effectively symmetric encryption on the data. The key
+  # below defines the private key for this host to be validated by the public
+  # key on the remote hosts, and naked pre-shared-keys which can be referenced
+  # in the peers configuration of the wireguard interface.
+  wireguard:
+    key: PRIVATE-KEY==
+    psk:
+      laptop: PRE-SHARED-KEY==
+      mobile: PRE-SHARED-KEY==
+
 # The network is only configured with a single bridge interface on each host
 # to which all physical are attached, and then all of these are variously
 # associated with VLANs in tagged and untagged configurations. This block
@@ -206,3 +217,52 @@ interfaces:
     # This is a 10GbE port, so reduce the cost, as per the above table
     cost: 2000
     comment: switch1 (trunk)
+
+  # A Wireguard interface is more complex than a standard interface as it
+  # requires information about the hosts expected to connect to it alongside
+  # the configuration of the interface itself.
+  - name: wgd01
+    enabled: true
+    # Ensure the type is set to wireguard to correctly configure the interface
+    type: wireguard
+    key: wgd01
+    port: 2133
+    mtu: 1420
+    # The address of this interface should both be the address which it should
+    # respond to, as well as the addresses to be expected to be found through
+    # this interface. A route to this range will be created automatically.
+    address: 172.16.254.1/24
+    peers:
+      # Each peer is a key/map entry here, defined with the public key
+      # associated with it, and a static address associated with that endpoint
+      # (which must exist within the range of addresses above)
+      server:
+        key: PUBLIC-KEY==
+        enabled: true
+        address: 172.16.254.2
+        # If this host is expected to be able to initiate a connection (i.e. it
+        # is a site-to-site tunnel), then add the address and port of the remote
+        # host under the endpoint key
+        endpoint:
+          address: 192.0.2.22
+          port: 2133
+        # If traffic is expected to be routed over this tunnel to the remote
+        # host, then add all the routes which are to be directed over this
+        # connection, which will be added as static entries.
+        routes:
+          - ipv4: 172.16.253.0/24
+            comment: Internal Services VLAN
+        comment: Web Server
+      # If any connection is to be a road-warrior type (i.e. incoming only and
+      # no routing), then just add the public key of the host and the IP address
+      # which is to be associated with the other end of the connection
+      laptop:
+        key: PUBLIC-KEY==
+        enabled: true
+        address: 172.27.254.3
+        comment: Personal Laptop
+      mobile:
+        key: PUBLIC-KEY==
+        enabled: true
+        address: 172.27.254.4
+        comment: Personal Laptop

--- a/examples/router.yaml
+++ b/examples/router.yaml
@@ -44,24 +44,6 @@ settings:
   mtu: 2000
   l2mtu: 2092
 
-  # Each host will have SSH enabled for remote access, including uploading these
-  # exported scripts to run. By setting the key here under SSH, the SSH host
-  # private key can be defined so that the host can provide a consistent public
-  # key to verify the host when connecting between updated or re-initialisations.
-  ssh:
-    key: |
-      -- PRIVATE KEY --
-
-  # Each host can have WebFig and the API made available over HTTPS for remote
-  # monitoring and management. If the key and certificate are set, like below,
-  # under ssl, then the appropriate certificates can be installed onto the host
-  # and then configured against the two services, and therefore enabling access.
-  ssl:
-    key: |
-      -- PRIVATE KEY --
-    certificate: |
-      -- CERTIFICATE --
-
   # Set the timezone for this server to properly configure the local time and
   # any checks for summer/winter times. This is based on the standard tz
   # database, more of which be found in the Wiki:
@@ -83,6 +65,29 @@ settings:
       comment: NTP Pool Project for United Kingdom
     - address: 3.uk.pool.ntp.org
       comment: NTP Pool Project for United Kingdom
+
+# The secrets map is a collection of values which cam be used as secrets,
+# specifically for this host, and mapped to by other values (e.g. ssh.key for
+# the private key for SSH on this host). Normally the secrets block should be
+# empty, and overridden by values from Vault.
+secrets:
+  # Each host will have SSH enabled for remote access, including uploading these
+  # exported scripts to run. By setting the key here under SSH, the SSH host
+  # private key can be defined so that the host can provide a consistent public
+  # key to verify the host when connecting between updated or re-initialisations.
+  ssh:
+    key: |
+      -- PRIVATE KEY --
+
+  # Each host can have WebFig and the API made available over HTTPS for remote
+  # monitoring and management. If the key and certificate are set, like below,
+  # under ssl, then the appropriate certificates can be installed onto the host
+  # and then configured against the two services, and therefore enabling access.
+  ssl:
+    key: |
+      -- PRIVATE KEY --
+    certificate: |
+      -- CERTIFICATE --
 
 # The network is only configured with a single bridge interface on each host
 # to which all physical are attached, and then all of these are variously

--- a/examples/switch.yaml
+++ b/examples/switch.yaml
@@ -16,6 +16,8 @@ description: |-
 
 settings:
   timezone: Europe/London
+
+secrets:
   ssh:
     key: |
       -- PRIVATE KEY --

--- a/examples/vault.json
+++ b/examples/vault.json
@@ -1,7 +1,11 @@
 {
   "secrets": {
     "ssh": {"key": "PRIVATE-KEY"},
-    "ssl": {"key": "PRIVATE-KEY", "certificate": "CERTIFICATE"}
+    "ssl": {"key": "PRIVATE-KEY", "certificate": "CERTIFICATE"},
+    "wireguard": {
+      "key": "PRIVATE-KEY",
+      "psk": {"laptop": "PRE-SHARED-KEY", "mobile": "PRE-SHARED-KEY"}
+    },
     "wifi": {
       "home": "this-is-the-psk-for-home-wifi",
       "guest": "this-is-the-psk-for-guest-wifi"

--- a/examples/vault.json
+++ b/examples/vault.json
@@ -1,0 +1,10 @@
+{
+  "secrets": {
+    "ssh": {"key": "PRIVATE-KEY"},
+    "ssl": {"key": "PRIVATE-KEY", "certificate": "CERTIFICATE"}
+    "wifi": {
+      "home": "this-is-the-psk-for-home-wifi",
+      "guest": "this-is-the-psk-for-guest-wifi"
+    }
+  }
+}

--- a/templates/exports/update.rsc.t
+++ b/templates/exports/update.rsc.t
@@ -12,4 +12,5 @@
 {{ template "parts/bridge.rsc.t" }}
 {{ template "parts/vlans.rsc.t" }}
 {{ template "parts/firewall.rsc.t" }}
+{{ template "parts/wireguard.rsc.t" }}
 {{ template "parts/footer.rsc.t" }}

--- a/templates/exports/wireguard.rsc.t
+++ b/templates/exports/wireguard.rsc.t
@@ -1,0 +1,5 @@
+{{ template "parts/header.rsc.t" "Wireguard" }}
+{{- /* vim:set ft=routeros: */}}
+
+{{  template "parts/wireguard.rsc.t" }}
+{{  template "parts/footer.rsc.t" }}

--- a/templates/parts/certificates.rsc.t
+++ b/templates/parts/certificates.rsc.t
@@ -32,9 +32,9 @@
 {{-   end }}
 {{- end }}
 
-{{- if (and (has (ds "host").settings "ssl")
-            (and (has (ds "host").settings.ssl "key")
-                 (has (ds "host").settings.ssl "certificate"))) }}
+{{- if (and (has (ds "host").secrets "ssl")
+            (and (has (ds "host").secrets.ssl "key")
+                 (has (ds "host").secrets.ssl "certificate"))) }}
 
 {{    template "component" "Host Certificate" }}
 
@@ -50,8 +50,8 @@
     [ :len [ /file find where name="{{ $name }}.pem" ] ] > 0 \
   ) do={ /file remove "{{ $name }}.pem" }
   /file add name="{{ $name }}.pem" \
-            contents="{{ (ds "host").settings.ssl.key | strings.Trim "\n" }}
-{{ (ds "host").settings.ssl.certificate | strings.Trim "\n" }}"
+            contents="{{ (ds "host").secrets.ssl.key | strings.Trim "\n" }}
+{{ (ds "host").secrets.ssl.certificate | strings.Trim "\n" }}"
   # This is needed to ensure the file is ready for reading by the import
   :delay 300ms
   /certificate import name="{{ $name }}" \

--- a/templates/parts/firewall-filter-check-ssh.rsc.t
+++ b/templates/parts/firewall-filter-check-ssh.rsc.t
@@ -33,7 +33,7 @@ add chain="$runId:check:ssh" \
 add chain="$runId:check:ssh" \
     src-address-list="!$runId:ssh:allowed" \
     action=drop \
-    log=yes \
+    log=no \
     log-prefix="DROP>" \
     comment="DROP all connections and packets not from allowed networks"
 
@@ -42,14 +42,14 @@ add chain="$runId:check:ssh" \
     connection-state=new \
     protocol=tcp \
     action=tarpit \
-    log=yes \
+    log=no \
     log-prefix="TARPIT!" \
     comment="TARPIT (hold open) new SSH connections from restricted hosts"
 
 add chain="$runId:check:ssh" \
     src-address-list="dynamic:ssh:restricted" \
     action=drop \
-    log=yes \
+    log=no \
     log-prefix="DROP!" \
     comment="DROP all other SSH packets from restricted hosts"
 
@@ -62,7 +62,7 @@ add chain="$runId:check:ssh" \
 add chain="$runId:check:ssh" \
     src-address-list="$runId:ssh:unrestricted" \
     action=drop \
-    log=yes \
+    log=no \
     log-prefix="DROP|" \
     comment="DROP, but do not restrict, unrestricted hosts if the rate limit is exceeded"
 
@@ -71,13 +71,13 @@ add chain="$runId:check:ssh" \
     action=add-src-to-address-list \
     address-list="dynamic:ssh:restricted" \
     address-list-timeout=26w \
-    log=yes \
+    log=no \
     log-prefix="TARPIT+" \
     comment="ADD the source host to restricted list if the rate limit is exceeded"
 
 add chain="$runId:check:ssh" \
     action=drop \
-    log=yes \
+    log=no \
     log-prefix="DROP!" \
     comment="DROP all other SSH connections and packets"
 
@@ -91,14 +91,14 @@ add chain="$runId:check:ssh" \
 add chain="$runId:check:ssh" \
     src-address-list="!$runId:ssh:allowed" \
     action=drop \
-    log=yes \
+    log=no \
     log-prefix="DROP>" \
     comment="DROP all connections and packets not from allowed networks"
 
 add chain="$runId:check:ssh" \
     src-address-list="dynamic:ssh:restricted" \
     action=drop \
-    log=yes \
+    log=no \
     log-prefix="DROP!" \
     comment="DROP all SSH packets from restricted hosts"
 
@@ -111,7 +111,7 @@ add chain="$runId:check:ssh" \
 add chain="$runId:check:ssh" \
     src-address-list="$runId:ssh:unrestricted" \
     action=drop \
-    log=yes \
+    log=no \
     log-prefix="DROP|" \
     comment="DROP, but do not restrict, unrestricted hosts if the rate limit is exceeded"
 
@@ -120,12 +120,12 @@ add chain="$runId:check:ssh" \
     action=add-src-to-address-list \
     address-list="dynamic:ssh:restricted" \
     address-list-timeout=26w \
-    log=yes \
+    log=no \
     log-prefix="DROP+" \
     comment="ADD the source host to restricted list if the rate limit is exceeded"
 
 add chain="$runId:check:ssh" \
     action=drop \
-    log=yes \
+    log=no \
     log-prefix="DROP!" \
     comment="DROP all other SSH connections and packets"

--- a/templates/parts/firewall-filter-forward-chain.rsc.t
+++ b/templates/parts/firewall-filter-forward-chain.rsc.t
@@ -46,6 +46,13 @@ add chain="$runId:forward" \
     comment="Process all NTP connections and packets"
 
 add chain="$runId:forward" \
+    protocol=tcp \
+    dst-port=22 \
+    action=jump \
+    jump-target="$runId:check:ssh" \
+    comment="Process all SSH connections and packets"
+
+add chain="$runId:forward" \
     connection-state=new \
     action=jump \
     jump-target="$runId:forward:ports" \

--- a/templates/parts/firewall-filter-input-external.rsc.t
+++ b/templates/parts/firewall-filter-input-external.rsc.t
@@ -99,7 +99,7 @@ add chain="$runId:input:external" \
 
 add chain="$runId:input:wireguard" \
     protocol=udp \
-    dst-port=52729 \
+    dst-port=2133 \
     action=accept \
     comment="ACCEPT all WireGuard connections"
 
@@ -107,7 +107,7 @@ add chain="$runId:input:wireguard" \
 
 add chain="$runId:input:wireguard" \
     protocol=udp \
-    dst-port=52729 \
+    dst-port=2133 \
     action=accept \
     comment="ACCEPT all WireGuard connections"
 

--- a/templates/parts/firewall-filter-output-external.rsc.t
+++ b/templates/parts/firewall-filter-output-external.rsc.t
@@ -16,15 +16,15 @@ add chain="$runId:output:external" \
             (eq (ds "host").type "router")) }}
 
 add chain="$runId:output:external" \
-    src-address-list="$runId:wireguard:trusted" \
+    dst-address-list="$runId:wireguard:trusted" \
     action=jump \
-    jump-target="$runId:output:external:wireguard" \
+    jump-target="$runId:output:wireguard" \
     comment="Process WireGuard connections to trusted hosts"
 
 add chain="$runId:output:external" \
-    src-address-list="$runId:ipsec:trusted" \
+    dst-address-list="$runId:ipsec:trusted" \
     action=jump \
-    jump-target="$runId:output:external:ipsec" \
+    jump-target="$runId:output:ipsec" \
     disabled=yes \
     comment="Process all IPsec connections to trusted hosts"
 
@@ -43,15 +43,15 @@ add chain="$runId:output:external" \
             (eq (ds "host").type "router")) }}
 
 add chain="$runId:output:external" \
-    src-address-list="$runId:wireguard:trusted" \
+    dst-address-list="$runId:wireguard:trusted" \
     action=jump \
-    jump-target="$runId:output:external:wireguard" \
+    jump-target="$runId:output:wireguard" \
     comment="Process WireGuard connections to trusted hosts"
 
 add chain="$runId:output:external" \
-    src-address-list="$runId:ipsec:trusted" \
+    dst-address-list="$runId:ipsec:trusted" \
     action=jump \
-    jump-target="$runId:output:external:ipsec" \
+    jump-target="$runId:output:ipsec" \
     disabled=yes \
     comment="Process all IPsec connections to trusted hosts"
 
@@ -60,50 +60,50 @@ add chain="$runId:output:external" \
 {{- if (and (ne (ds "host").export "netinstall")
             (eq (ds "host").type "router")) }}
 
-{{ template "item" "filter/output:external:wireguard chain" }}
+{{ template "item" "filter/output:wireguard chain" }}
 
 /ip firewall filter
 
-add chain="$runId:output:external:wireguard" \
+add chain="$runId:output:wireguard" \
     protocol=udp \
-    dst-port=52729 \
+    dst-port=2133 \
     action=accept \
     comment="ACCEPT all WireGuard connections"
 
 /ipv6 firewall filter
 
-add chain="$runId:output:external:wireguard" \
+add chain="$runId:output:wireguard" \
     protocol=udp \
-    dst-port=52729 \
+    dst-port=2133 \
     action=accept \
     comment="ACCEPT all WireGuard connections"
 
-{{ template "item" "filter/output:external:ipsec chain" }}
+{{ template "item" "filter/output:ipsec chain" }}
 
 /ip firewall filter
 
-add chain="$runId:output:external:ipsec" \
+add chain="$runId:output:ipsec" \
     ipsec-policy=out,ipsec \
     action=accept \
     comment="ACCEPT all connections encrypted via IPsec"
 
-add chain="$runId:output:external:ipsec" \
+add chain="$runId:output:ipsec" \
     protocol=ipsec-esp \
     action=accept \
     comment="ACCEPT all ESP connections encrypted"
 
-add chain="$runId:output:external:ipsec" \
+add chain="$runId:output:ipsec" \
     protocol=ipsec-ah \
     action=accept \
     comment="ACCEPT all AH connections encrypted"
 
-add chain="$runId:output:external:ipsec" \
+add chain="$runId:output:ipsec" \
     protocol=udp \
     dst-port=4500 \
     action=accept \
     comment="ACCEPT IKEv2 connections"
 
-add chain="$runId:output:external:ipsec" \
+add chain="$runId:output:ipsec" \
     protocol=udp \
     dst-port=500 \
     action=accept \
@@ -112,28 +112,28 @@ add chain="$runId:output:external:ipsec" \
 
 /ipv6 firewall filter
 
-add chain="$runId:output:external:ipsec" \
+add chain="$runId:output:ipsec" \
     ipsec-policy=out,ipsec \
     action=accept \
     comment="ACCEPT all connections encrypted via IPsec"
 
-add chain="$runId:output:external:ipsec" \
+add chain="$runId:output:ipsec" \
     protocol=ipsec-esp \
     action=accept \
     comment="ACCEPT all ESP connections encrypted"
 
-add chain="$runId:output:external:ipsec" \
+add chain="$runId:output:ipsec" \
     protocol=ipsec-ah \
     action=accept \
     comment="ACCEPT all AH connections encrypted"
 
-add chain="$runId:output:external:ipsec" \
+add chain="$runId:output:ipsec" \
     protocol=udp \
     dst-port=4500 \
     action=accept \
     comment="ACCEPT IKEv2 connections"
 
-add chain="$runId:output:external:ipsec" \
+add chain="$runId:output:ipsec" \
     protocol=udp \
     dst-port=500 \
     action=accept \

--- a/templates/parts/firewall-filter-reject.rsc.t
+++ b/templates/parts/firewall-filter-reject.rsc.t
@@ -34,7 +34,7 @@ add chain="$runId:reject" \
     dst-limit=3/5m,5,src-and-dst-addresses/3h \
     action=reject \
     reject-with=icmp-admin-prohibited \
-    log=yes \
+    log=no \
     log-prefix="REJECT!" \
     comment="Politely REJECT all connections with ICMP response (rated limited to 5/min)"
 

--- a/templates/parts/firewall-filter-tarpit.rsc.t
+++ b/templates/parts/firewall-filter-tarpit.rsc.t
@@ -47,7 +47,7 @@ add chain="$runId:tarpit" \
     action=add-src-to-address-list \
     address-list="dynamic:tarpit:restricted" \
     address-list-timeout=26w \
-    log=yes \
+    log=no \
     log-prefix="TARPIT+" \
     comment="Add source host to restricted list if rate limit exceeded"
 
@@ -66,7 +66,7 @@ add chain="$runId:tarpit:drop" \
 
 add chain="$runId:tarpit:drop" \
     action=drop \
-    log=yes \
+    log=no \
     log-prefix="DROP!" \
     comment="DROP all other packet types from restricted hosts silently"
 
@@ -103,7 +103,7 @@ add chain="$runId:tarpit" \
     action=add-src-to-address-list \
     address-list="dynamic:tarpit:restricted" \
     address-list-timeout=26w \
-    log=yes \
+    log=no \
     log-prefix="TARPIT+" \
     comment="Add source host to restricted list if rate limit exceeded"
 
@@ -114,6 +114,6 @@ add chain="$runId:tarpit" \
 
 add chain="$runId:tarpit:drop" \
     action=drop \
-    log=yes \
+    log=no \
     log-prefix="DROP!" \
     comment="DROP all packets from restricted hosts silently"

--- a/templates/parts/header.rsc.t
+++ b/templates/parts/header.rsc.t
@@ -10,8 +10,6 @@
 {{- define "section" -}}
 :log info "{{ (ds "host").export }}.rsc/$runId: {{ . }}"
 {{-   if (not (eq (ds "host").export "netinstall")) }}
-:put "╶──>                                             "
-:terminal cuu
 :put "╶──> {{ . }}"
 {{-   end -}}
 {{- end }}
@@ -19,7 +17,6 @@
 {{- define "error" -}}
 :log error "{{ (ds "host").export }}.rsc/$runId: {{ . }}"
 {{-   if (not (eq (ds "host").export "netinstall")) }}
-:put ""
 :terminal style error
 :put " ╶─> {{ . }}"
 :terminal style none
@@ -29,8 +26,6 @@
 {{- define "component" -}}
 :log info "{{ (ds "host").export }}.rsc/$runId: {{ . }}"
 {{-   if (not (eq (ds "host").export "netinstall")) }}
-:put " ╶─>                                             "
-:terminal cuu
 :put " ╶─> {{ . }}"
 {{-   end -}}
 {{- end }}
@@ -38,10 +33,7 @@
 {{- define "item" -}}
 :log info "{{ (ds "host").export }}.rsc/$runId: {{ . }}"
 {{-   if (not (eq (ds "host").export "netinstall")) }}
-:put "  ╶>                                             "
-:terminal cuu
 :put "  ╶> {{ . }}"
-:terminal cuu
 {{-   end -}}
 {{- end }}
 

--- a/templates/parts/ssh.rsc.t
+++ b/templates/parts/ssh.rsc.t
@@ -24,8 +24,8 @@ set forwarding-enabled=no \
     strong-crypto=yes
 
 {{- if (and (eq (ds "host").export "certificates")
-            (and (has (ds "host").settings "ssh")
-                 (has (ds "host").settings.ssh "key"))) }}
+            (and (has (ds "host").secrets "ssh")
+                 (has (ds "host").secrets.ssh "key"))) }}
 
 /file
 
@@ -34,7 +34,7 @@ set forwarding-enabled=no \
   [ :len [ find where name="ssh-host-key.pem" ] ] > 0 \
 ) do={ remove "ssh-host-key.pem" }
 add name="ssh-host-key.pem" \
-    contents="{{ (ds "host").settings.ssh.key | strings.Trim "\n" }}"
+    contents="{{ (ds "host").secrets.ssh.key | strings.Trim "\n" }}"
 
 # This is needed to ensure the file is ready for reading by the import
 :delay 250ms

--- a/templates/parts/wireguard.rsc.t
+++ b/templates/parts/wireguard.rsc.t
@@ -1,0 +1,186 @@
+# -- templates/parts/wireguard.rsc.t
+{{- /* vim:set ft=routeros: */}}
+# Configure the Wireguard VPN Service, setting up each of the required
+# interfaces, and attaching the peers and IP addresses, and routing
+# configurations needed.
+
+{{- $i_defaults := coll.Dict "enabled" false "type" "ethernet" "vlan" "blocked" "comment" "" "mtu" 1420 "address" coll.Dict }}
+{{- $p_defaults := coll.Dict "enabled" false "comment" "" "keepalive" 0 }}
+{{- $interfaces := coll.Slice }}
+
+{{  template "section" "Set up Wireguard Interfaces" }}
+
+/interface wireguard
+
+{{  template "component" "Configure the Interfaces" }}
+
+{{- range $i := (ds "host").interfaces }}
+{{-   $i = merge $i $i_defaults }}
+
+{{-   if (or (eq (ds "host").export "netinstall")
+             (ne $i.type "wireguard")) }}
+{{-     continue }}
+{{-   end}}
+
+{{-   $interfaces = $interfaces | append $i.name }}
+
+{{    template "item" $i.name }}
+
+:if ( \
+  [ :len [ find where name="{{ $i.name }}" ] ] = 0 \
+) do={ add name="{{ $i.name }}" listen-port="{{ $i.port }}" private-key="{{ $i.key }}" }
+set [ find where name="{{ $i.name }}" ] \
+    private-key="{{ $i.key }}" \
+    listen-port="{{ $i.port }}" \
+    mtu={{ $i.mtu }} \
+    disabled={{ if $i.enabled }}no{{ else }}yes{{ end }} \
+    comment="{{ $i.comment }}"
+
+{{-   if (has $i.address "ipv4") }}
+{{-     $prefix := (index ($i.address.ipv4 | strings.Split "/") 1) }}
+{{-     $network := (index ((net.ParseIPPrefix $i.address.ipv4).Range | strings.Split "-") 0) }}
+
+/ip address
+
+:if ( \
+  [ :len [ find where interface="{{ $i.name }}" ] ] = 0 \
+) do={ add interface="{{ $i.name }}" address="{{ $i.address.ipv4 }}" }
+set [ find where interface="{{ $i.name }}" ] \
+    address={{ $i.address.ipv4 }} \
+    network={{ $network }} \
+    disabled={{ if $i.enabled }}no{{ else }}yes{{ end }} \
+    comment="{{ $i.comment }}"
+
+{{-   end }}
+
+{{-   if (has $i.address "ipv6") }}
+{{-     $prefix := (index ($i.address.ipv6 | strings.Split "/") 1) }}
+{{-     $network := (index ((net.ParseIPPrefix $i.address.ipv6).Range | strings.Split "-") 0) }}
+
+/ipv6 address
+
+:if ( \
+  [ :len [ find where interface="{{ $i.name }}" ] ] = 0 \
+) do={ add interface="{{ $i.name }}" address="{{ $i.address.ipv4 }}" }
+set [ find where interface="{{ $i.name }}" ] \
+    address={{ $i.address.ipv6 }} \
+    no-dad=yes \
+    disabled={{ if $i.enabled }}no{{ else }}yes{{ end }} \
+    comment="{{ $i.comment }}"
+
+{{-   end }}
+
+/interface wireguard peers
+
+{{-   $ipv4_routes := coll.Slice }}
+{{-   $ipv6_routes := coll.Slice }}
+{{-   range $p := $i.peers }}
+{{-     $p = merge $p $p_defaults }}
+{{-     $allowed := coll.Slice }}
+
+{{-     range $r := $p.routes }}
+{{-       if (has $r "ipv4") }}
+{{-         $allowed = $allowed | append $r.ipv4 }}
+{{-         if (and $i.enabled $p.enabled) }}
+{{-           $ipv4_routes = $ipv4_routes | append $r.ipv4 }}
+{{-         end }}
+{{-       end }}
+{{-       if (has $r "ipv6") }}
+{{-         $allowed = $allowed | append $r.ipv6 }}
+{{-         if (and $i.enabled $p.enabled) }}
+{{-           $ipv6_routes = $ipv6_routes | append $r.ipv6 }}
+{{-         end }}
+{{-       end }}
+{{-     end }}
+
+{{      template "item" (print $i.name "/" $p.name) }}
+
+:if ( \
+  [ :len [ find where interface="{{ $i.name }}" and public-key="{{ $p.key }}" ] ] = 0 \
+) do={ add interface="{{ $i.name }}" public-key="{{ $p.key }}" }
+set [ find where interface="{{ $i.name }}" and public-key="{{ $p.key }}" ] \
+{{-       if (gt $p.keepalive 0) }}
+    persistent-keepalive={{ $p.keepalive}}s \
+{{-     end }}
+{{-     if (has $p "endpoint") }}
+    endpoint-address={{ $p.endpoint.address }} \
+    endpoint-port={{ $p.endpoint.port }} \
+{{-     end }}
+    allowed-address={{ join $allowed "," }} \
+    disabled={{ if $p.enabled }}no{{ else }}yes{{ end }} \
+    comment="{{ $p.name }} ({{ $p.comment }})"
+
+{{-     $has_ipv4_route := false }}
+{{-     range $r := $p.routes }}
+
+{{-       if (not (has $r "ipv4")) }}
+{{-         continue }}
+{{-       end }}
+
+{{-       if (not $has_ipv4_route) }}
+{{-         $has_ipv4_route = true }}
+
+/ip route
+
+{{-       end }}
+
+:if ( \
+  [ :len [ find where gateway="{{ $i.name }}" and dst-address="{{ $r.ipv4 }}" ] ] = 0 \
+) do={ add gateway="{{ $i.name }}" dst-address="{{ $r.ipv4 }}" }
+set [ find where gateway="{{ $i.name }}" and dst-address="{{ $r.ipv4 }}" ] \
+  disabled={{ if (and $i.enabled $p.enabled) }}no{{ else }}yes{{ end }} \
+  comment="{{ $i.comment }} ({{ $r.comment}} for {{ $p.comment }})"
+
+{{-     end }}
+
+{{-     $has_ipv6_route := false }}
+{{-     range $r := $p.routes }}
+
+{{-       if (not (has $r "ipv6")) }}
+{{-         continue }}
+{{-       end }}
+
+{{-       if (not $has_ipv6_route) }}
+{{-         $has_ipv6_route = true }}
+
+/ipv6 route
+
+{{-       end }}
+
+:if ( \
+  [ :len [ find where gateway="{{ $i.name }}" and dst-address="{{ $r.ipv6 }}" ] ] = 0 \
+) do={ add gateway="{{ $i.name }}" dst-address="{{ $r.ipv6 }}" }
+set [ find where gateway="{{ $i.name }}" and dst-address="{{ $r.ipv6 }}" ] \
+  disabled={{ if (and $i.enabled $p.enabled) }}no{{ else }}yes{{ end }} \
+  comment="{{ $i.comment }} ({{ $r.comment}} for {{ $p.comment }})"
+
+{{-     end }}
+
+{{-   end }}
+
+/ip route
+
+remove [
+  find where gateway="{{ $i.name }}"
+]
+
+/ipv6 route
+
+remove [
+  find where gateway="{{ $i.name }}" \
+]
+
+{{- end }}
+
+# Delete unknown peer
+# Delete unknown Wireguard interfaces (including IP Addresses)
+
+/interface wireguard
+
+# How to remove route for deleted interfaces?
+
+remove [
+  find where !(
+    name={{ conv.Join $interfaces " or \\\n    name=" }}
+  )
+]

--- a/templates/parts/wireless.rsc.t
+++ b/templates/parts/wireless.rsc.t
@@ -16,6 +16,11 @@
 {{-   $v := merge $v $v_defaults }}
 {{-   if (has $v "wifi") }}
 {{-     $profiles = $profiles | append $v.name }}
+{{-     $psk := "" }}
+{{-     if (and (and (has $v.wifi "psk") (has $v.wifi.psk "secret"))
+                (has (ds "network").secrets.wifi $v.wifi.psk.secret)) }}
+{{-       $psk = (index (ds "network").secrets.wifi $v.wifi.psk.secret) }}
+{{-     end }}
 
 {{      template "item" $v.name }}
 
@@ -24,9 +29,13 @@
 ) do={ add name="{{ $v.name }}" }
 
 set [ find where name="{{ $v.name }}" ] \
+{{-     if (eq $psk "") }}
+    mode=none
+{{-     else }}
     mode=dynamic-keys \
     authentication-types=wpa2-psk \
-    wpa2-pre-shared-key="{{ $v.wifi.psk }}"
+    wpa2-pre-shared-key="{{ $psk }}"
+{{-     end }}
 
 {{-   end }}
 {{- end }}


### PR DESCRIPTION
Refactor secrets handling and some firewall configuration, then add the configuration for additional secrets needed for WireGuard (i.e., the host's private key and any pre-shared keys for authentication) and support the creation of a WireGuard-type interface.

Fix some chain names as well, removing external where not required.

## Checklist

Please confirm the following checks:

- [x] My pull request follows the guidelines set out in `CONTRIBUTING.md`.
- [x] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my code and corrected any misspellings.
- [x] Each commit in this pull request has a meaningful subject & body for context.
- [x] I have squashed all "fix(up)" commits to provide a clean code history.
- [x] My pull request has an appropriate title and description for context.
- [ ] I have linked this pull request to other issues or pull requests as needed.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels as needed.
