### PR TITLE
Fix IPv6 DHCP client requests and server responses

### DIFF
--- a/templates/parts/firewall-filter-input.rsc.t
+++ b/templates/parts/firewall-filter-input.rsc.t
@@ -143,11 +143,23 @@ add chain="$runId:input" \
 {{- if (eq (ds "host").type "router") }}
 
 add chain="$runId:input" \
+    in-interface-list=external \
     src-address=fe80::/16 \
+    dst-address=fe80::1 \
+    protocol=udp \
+    src-port=547 \
+    dst-port=546 \
+    action=accept \
+    comment="ACCEPT DHCPv6 prefix responses from external interfaces"
+
+add chain="$runId:input" \
+    in-interface-list=internal \
+    src-address=fe80::/16 \
+    dst-address=fe80::/16 \
     protocol=udp \
     dst-port=547 \
     action=accept \
-    comment="ACCEPT DHCPv6 server requests"
+    comment="ACCEPT DHCPv6 client requests from internal interfaces"
 
 {{- end }}
 

--- a/templates/parts/firewall-filter-output.rsc.t
+++ b/templates/parts/firewall-filter-output.rsc.t
@@ -117,10 +117,24 @@ add chain="$runId:output" \
 {{- if (eq (ds "host").type "router") }}
 
 add chain="$runId:output" \
-    src-address=fe80::/16 \
-    protocol=udp dst-port=546 \
+    out-interface-list=external \
+    src-address=fe80::1 \
+    dst-address=ff02::/16 \
+    protocol=udp \
+    src-port=546 \
+    dst-port=547 \
     action=accept \
-    comment="ACCEPT DHCPv6 client responses"
+    comment="ACCEPT DHCPv6 server requests via external interfaces"
+
+add chain="$runId:output" \
+    out-interface-list=internal \
+    src-address=fe80::/16 \
+    dst-address=fe80::/16 \
+    protocol=udp \
+    src-port=547 \
+    dst-port=546 \
+    action=accept \
+    comment="ACCEPT DHCPv6 client responses via internal interfaces"
 
 {{- end }}
 

--- a/templates/parts/wireless.rsc.t
+++ b/templates/parts/wireless.rsc.t
@@ -9,7 +9,7 @@
 
 {{  template "component" "Configure the wireless Profiles" }}
 
-/interface wireless security
+/interface wireless security-profiles
 
 {{- $profiles := coll.Slice }}
 {{- range $v := (ds "network").vlans }}


### PR DESCRIPTION
Fix the IPv6 firewall filter rules to support DHCPv6 client requests on
external interfaces, and DHCPv6 server responses for internal
interfaces.

## Checklist

Please check and confirm the following items have been performed, where
possible, for this Pull Request:

- [x] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] Each commit in, and this pull request, have meaningful subject & body for context.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels, as needed.
